### PR TITLE
Fix nvcc link issue for alltoall in cuda 11.6+

### DIFF
--- a/src/collectives/device/Makefile
+++ b/src/collectives/device/Makefile
@@ -12,7 +12,7 @@ OBJDIR := $(BUILDDIR)/obj/collectives/device
 
 LIBSRCFILES := all_reduce.cu broadcast.cu reduce.cu all_gather.cu reduce_scatter.cu all_to_all.cu sendrecv.cu custom_collective.cu
 
-LIBSRCFILES += functions.cu stride_copy.cu
+LIBSRCFILES += functions.cu
 
 DEPFILES   := $(patsubst %.cu, $(OBJDIR)/%.d, $(LIBSRCFILES))
 DEPENDFILES:= $(DEPFILES:%.d=%.dep)
@@ -36,11 +36,14 @@ $(RULESFILE) :
 
 -include $(RULESFILE)
 
-LIBOBJ     := $(GENOBJS) $(OBJDIR)/functions.o $(OBJDIR)/stride_copy.o
+LIBOBJ     := $(GENOBJS) $(OBJDIR)/functions.o
+
+CUSTOMLIBOBJ := $(OBJDIR)/stride_copy_lib.o
+CUSTOMDEVOBJ := $(OBJDIR)/stride_copy_dev.o
 
 -include $(DEPFILES)
 
-$(STATICLIB): $(LIBOBJ) $(DEVOBJ)
+$(STATICLIB): $(LIBOBJ) $(DEVOBJ) $(CUSTOMLIBOBJ) $(CUSTOMDEVOBJ)
 	@printf "Archiving  %-35s > %s\n" objects $@
 	ar cr $@ $^
 
@@ -63,10 +66,15 @@ $(OBJDIR)/functions.o : functions.cu $(OBJDIR)/functions.dep
 	mkdir -p `dirname $@`
 	$(NVCC) $(NVCUFLAGS) -dc $< -o $@
 
-$(OBJDIR)/stride_copy.o : stride_copy.cu $(OBJDIR)/stride_copy.dep
+$(OBJDIR)/%_lib.o : %.cu
 	@printf "Compiling  %-35s > %s\n" $< $@
 	mkdir -p `dirname $@`
 	$(NVCC) $(NVCUFLAGS) -dc $< -o $@
+
+$(OBJDIR)/%_dev.o : $(OBJDIR)/%_lib.o
+	@printf "Compiling  %-35s > %s\n" $< $@
+	mkdir -p `dirname $@`
+	$(NVCC) $(NVCUFLAGS) -dlink $< -o $@
 
 # ... and create the device-side linked object with all those.
 $(DEVOBJ) : $(LIBOBJ)

--- a/src/collectives/device/stride_copy.cu
+++ b/src/collectives/device/stride_copy.cu
@@ -1,6 +1,6 @@
 #include "devcomm.h"
 
-/*static int strideMemcpyGridsize = 0, strideMemcpyBlocksize = 0;
+static int strideMemcpyGridsize = 0, strideMemcpyBlocksize = 0;
 
 // memory stride copy kernel
 template <typename T>
@@ -12,14 +12,14 @@ __global__ void strideMemcpyKernel(T *__restrict__ out, const T *__restrict__ in
     out[j] = in[i];
   }
 }
-*/
+
 cudaError_t strideMemcpyAsync(void *dst, const void *src, const size_t size, const int height, const int width, cudaStream_t stream) {
-/*  if (strideMemcpyGridsize == 0 || strideMemcpyBlocksize == 0)
+  if (strideMemcpyGridsize == 0 || strideMemcpyBlocksize == 0)
     cudaOccupancyMaxPotentialBlockSize(&strideMemcpyGridsize, &strideMemcpyBlocksize, strideMemcpyKernel<uint4>);
 
   if (size < sizeof(uint4))
     strideMemcpyKernel<char><<<strideMemcpyGridsize, strideMemcpyBlocksize, 0, stream>>>((char*)dst, (char*)src, size, height, width);
   else
-    strideMemcpyKernel<uint4><<<strideMemcpyGridsize, strideMemcpyBlocksize, 0, stream>>>((uint4*)dst, (uint4*)src, size/sizeof(uint4), height, width);*/
+    strideMemcpyKernel<uint4><<<strideMemcpyGridsize, strideMemcpyBlocksize, 0, stream>>>((uint4*)dst, (uint4*)src, size/sizeof(uint4), height, width);
   return cudaSuccess;
 }


### PR DESCRIPTION
There're runtime errors when build in cuda 11.6 or above, which are related to linking in nvcc:
* 11.6~11.6.2: "invalid device function"
* 11.7: "named symbol not found"

This fix links stride_copy obj file with relocatable device code into a separate obj file with executable device code than nccl's collectives, then archiving both of them in the static library.