### PR TITLE
Fix syncthreads

### DIFF
--- a/src/collectives/device/msccl_interpreter.h
+++ b/src/collectives/device/msccl_interpreter.h
@@ -134,7 +134,7 @@ namespace {
           int thisCount = min(mscclMaxAllowedCount, count-c);
           int thisNelem = nelem*thisCount;
           if (msccltran->type == MSCCL_SEND)
-            prims.sendWithBarrier(srcoffset, thisNelem);
+            prims.sendWithBarrier(srcoffset, thisNelem); // LL.send is the only situation where there is no barrier at the end.
           else if (msccltran->type == MSCCL_RECV)
             prims.recv(dstoffset, thisNelem);
           else if (msccltran->type == MSCCL_REDUCE) {

--- a/src/collectives/device/msccl_interpreter.h
+++ b/src/collectives/device/msccl_interpreter.h
@@ -175,12 +175,9 @@ namespace {
           else
             return;
         }
-        if (msccltran->has_dependence){
-          if (tid == nthreads-1){
-            // __threadfence();
-            uint64_t curFlag = COMPUTE_FLAG(workIndex, iter, step);
-            mscclFlags[bid].flag = curFlag;
-          }
+        if (msccltran->has_dependence && tid == nthreads-1){
+          uint64_t curFlag = COMPUTE_FLAG(workIndex, iter, step);
+          mscclFlags[bid].flag = curFlag;
         }
         step++;
       }

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -346,6 +346,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p>:
       nelem -= eltPerTrip;
       offset += nthreads;
     }
+    barrier();
   }
 
   __device__ __forceinline__ void loadRecvConn(struct ncclConnInfo* conn, int i) {
@@ -423,6 +424,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p>:
   __device__ void send(intptr_t inpIx, int eltN) {
     return LLGenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
   }
+  __device__ void sendWithBarrier(intptr_t inpIx, int eltN) {
+    send(inpIx, eltN);
+    barrier();
+  }  
   __device__ void sendFromOutput(intptr_t outIx, int eltN) {
     return LLGenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
   }

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -426,6 +426,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p>:
   }
   __device__ void sendWithBarrier(intptr_t inpIx, int eltN) {
     send(inpIx, eltN);
+    // only primitive.instruction where there is no barrier at the end
     barrier();
   }  
   __device__ void sendFromOutput(intptr_t outIx, int eltN) {

--- a/src/collectives/device/prims_ll128.h
+++ b/src/collectives/device/prims_ll128.h
@@ -394,7 +394,6 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p>:
       }    
       nelem -= DataEltPerSlice*nwarps;
     }
-
     barrier();
   }
 
@@ -479,6 +478,9 @@ public:
   __device__ void send(intptr_t inpIx, int eltN) {
     return GenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
   }
+  __device__ void sendWithBarrier(intptr_t inpIx, int eltN) {
+    send(inpIx, eltN);
+  }  
   __device__ void sendFromOutput(intptr_t outIx, int eltN) {
     return GenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
   }

--- a/src/collectives/device/prims_simple.h
+++ b/src/collectives/device/prims_simple.h
@@ -257,6 +257,7 @@ class Primitives<
         }
       }
     }
+    barrier();
   }
 
   // Scatter/Gather generic op
@@ -569,6 +570,9 @@ class Primitives<
   __device__ __forceinline__ void send(intptr_t inpIx, int eltN) {
     genericOp<0, 0, 0, 1, Input, -1>(inpIx, -1, -1, eltN, false);
   }
+  __device__ __forceinline__ void sendWithBarrier(intptr_t inpIx, int eltN) {
+    send(inpIx, eltN);
+  }  
   __device__ __forceinline__ void sendFromOutput(intptr_t outIx, int eltN) {
     genericOp<0, 0, 0, 1, Output, -1>(outIx, -1, -1, eltN, false);
   }


### PR DESCRIPTION
when counts are different, we may have a situation where a reduction followed by a send may not be in sync, especially for LL protocol. This commit makes sure that there is a syncthreads between instructions within the same threadblock regardless of hasdep filed.