### PR TITLE
include cstdint

### DIFF
--- a/src/include/collectives.h
+++ b/src/include/collectives.h
@@ -6,6 +6,7 @@
 
 #ifndef NCCL_COLLECTIVES_H_
 #define NCCL_COLLECTIVES_H_
+#include <cstdint>
 
 enum ncclDevRedOp_t {
   ncclDevSum, ncclDevProd, ncclDevMax, ncclDevMin,


### PR DESCRIPTION
There's compiling error:
```
../../include/collectives.h(18): error: identifier "uint64_t" is undefined
    uint64_t scalarArg;
```
I'm using CUDA 12.1 on Nvidia A100, with arch specified as `sm75`.
So it would be better to manually include the header.