### PR TITLE
fix missing signature

### DIFF
--- a/src/init.cc
+++ b/src/init.cc
@@ -1248,3 +1248,8 @@ ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) {
   *rank = comm->rank;
   return ncclSuccess;
 }
+
+NCCL_API(const char*, ncclGetLastError, const ncclComm_t comm);
+const char* ncclGetLastError(ncclComm_t comm) {
+  return "";
+}

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -379,6 +379,10 @@ ncclResult_t pncclGroupStart();
 ncclResult_t  ncclGroupEnd();
 ncclResult_t pncclGroupEnd();
 
+const char*  ncclGetLastError(ncclComm_t comm);
+const char* pncclGetLastError(ncclComm_t comm);
+
+
 #ifdef __cplusplus
 } // end extern "C"
 #endif


### PR DESCRIPTION
This bug fixes `ncclGetLastError` missing signature that is needed by newer PyTorch.